### PR TITLE
feat: Add hive-standalone to the bitnami image

### DIFF
--- a/14/debian-10/Dockerfile
+++ b/14/debian-10/Dockerfile
@@ -35,6 +35,33 @@ ENV APP_VERSION="14.3.0" \
 
 VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
+ARG HADOOP_VERSION=3.2.0
+#Hive standalone
+RUN apt-get update && apt-get install -y curl --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+RUN curl https://archive.apache.org/dist/hadoop/core/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz \
+	| tar xvz -C /opt/  \
+	&& ln -s /opt/hadoop-$HADOOP_VERSION /opt/hadoop \
+	&& rm -r /opt/hadoop/share/doc
+# Add S3a jars to the classpath using this hack.
+RUN ln -s /opt/hadoop/share/hadoop/tools/lib/hadoop-aws* /opt/hadoop/share/hadoop/common/lib/ && \
+    ln -s /opt/hadoop/share/hadoop/tools/lib/aws-java-sdk* /opt/hadoop/share/hadoop/common/lib/
+
+# Set necessary environment variables.
+ENV HADOOP_HOME="/opt/hadoop"
+ENV PATH="/opt/spark/bin:/opt/hadoop/bin:${PATH}"
+
+# Download and install the standalone metastore binary.
+RUN curl http://apache.uvigo.es/hive/hive-standalone-metastore-3.0.0/hive-standalone-metastore-3.0.0-bin.tar.gz \
+	| tar xvz -C /opt/ \
+	&& ln -s /opt/apache-hive-metastore-3.0.0-bin /opt/hive-metastore
+
+# Download and install the mysql connector.
+RUN curl -L https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.47.tar.gz \
+	| tar xvz -C /opt/ \
+	&& ln -s /opt/mysql-connector-java-5.1.47/mysql-connector-java-5.1.47.jar /opt/hadoop/share/hadoop/common/lib/ \
+	&& ln -s /opt/mysql-connector-java-5.1.47/mysql-connector-java-5.1.47.jar /opt/hive-metastore/lib/
+
 EXPOSE 5432
 
 USER 1001

--- a/14/debian-10/Dockerfile
+++ b/14/debian-10/Dockerfile
@@ -35,6 +35,7 @@ ENV APP_VERSION="14.3.0" \
 
 VOLUME [ "/bitnami/postgresql", "/docker-entrypoint-initdb.d", "/docker-entrypoint-preinitdb.d" ]
 
+# Modification to the Bitnami image to include hive-metastore-standalone
 ARG HADOOP_VERSION=3.2.0
 #Hive standalone
 RUN apt-get update && apt-get install -y curl --no-install-recommends \
@@ -52,16 +53,11 @@ ENV HADOOP_HOME="/opt/hadoop"
 ENV PATH="/opt/spark/bin:/opt/hadoop/bin:${PATH}"
 
 # Download and install the standalone metastore binary.
-RUN curl http://apache.uvigo.es/hive/hive-standalone-metastore-3.0.0/hive-standalone-metastore-3.0.0-bin.tar.gz \
+RUN curl https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore/3.0.0/hive-standalone-metastore-3.0.0-bin.tar.gz \
 	| tar xvz -C /opt/ \
 	&& ln -s /opt/apache-hive-metastore-3.0.0-bin /opt/hive-metastore
 
-# Download and install the mysql connector.
-# RUN curl -L https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.47.tar.gz \
-# 	| tar xvz -C /opt/ \
-# 	&& ln -s /opt/mysql-connector-java-5.1.47/mysql-connector-java-5.1.47.jar /opt/hadoop/share/hadoop/common/lib/ \
-# 	&& ln -s /opt/mysql-connector-java-5.1.47/mysql-connector-java-5.1.47.jar /opt/hive-metastore/lib/
-
+# Install the postgresql connector
 ENV PG_CONNECTOR_VERSION=42.3.6
 RUN curl -L https://jdbc.postgresql.org/download/postgresql-$PG_CONNECTOR_VERSION.jar --output /opt/postgresql-$PG_CONNECTOR_VERSION.jar \
     && ln -s /opt/postgresql-$PG_CONNECTOR_VERSION.jar /opt/hadoop/share/hadoop/common/lib/ \
@@ -69,6 +65,7 @@ RUN curl -L https://jdbc.postgresql.org/download/postgresql-$PG_CONNECTOR_VERSIO
 
 EXPOSE 5432
 
+# Install jdk 11 - needed for hadoop and hive
 RUN apt-get update && \
     apt-get install -y openjdk-11-jdk ca-certificates-java && \
     apt-get clean && \
@@ -76,10 +73,10 @@ RUN apt-get update && \
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
 RUN export JAVA_HOME
 
-ADD conf/metastore-log4j2.properties /opt/hive-metastore/conf
-ADD /rootfs/opt/bitnami/scripts/postgresql/entrypoint.sh /opt/hive-metastore/bin/entrypoint.sh
-RUN chmod 755 /opt/hive-metastore/bin/entrypoint.sh
 
-ENTRYPOINT [ "/opt/hive-metastore/bin/entrypoint.sh" ]
-USER 1001
+RUN chmod 755 /opt/bitnami/scripts/postgresql/entrypoint.sh
+ENV PATH="/opt/apache-hive-metastore-3.0.0-bin/conf:$PATH"
+ENTRYPOINT [ "/opt/bitnami/scripts/postgresql/entrypoint.sh" ]
+
+EXPOSE 9083
 CMD [ "/opt/bitnami/scripts/postgresql/run.sh" ]

--- a/14/debian-10/Dockerfile
+++ b/14/debian-10/Dockerfile
@@ -57,10 +57,15 @@ RUN curl http://apache.uvigo.es/hive/hive-standalone-metastore-3.0.0/hive-standa
 	&& ln -s /opt/apache-hive-metastore-3.0.0-bin /opt/hive-metastore
 
 # Download and install the mysql connector.
-RUN curl -L https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.47.tar.gz \
-	| tar xvz -C /opt/ \
-	&& ln -s /opt/mysql-connector-java-5.1.47/mysql-connector-java-5.1.47.jar /opt/hadoop/share/hadoop/common/lib/ \
-	&& ln -s /opt/mysql-connector-java-5.1.47/mysql-connector-java-5.1.47.jar /opt/hive-metastore/lib/
+# RUN curl -L https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.47.tar.gz \
+# 	| tar xvz -C /opt/ \
+# 	&& ln -s /opt/mysql-connector-java-5.1.47/mysql-connector-java-5.1.47.jar /opt/hadoop/share/hadoop/common/lib/ \
+# 	&& ln -s /opt/mysql-connector-java-5.1.47/mysql-connector-java-5.1.47.jar /opt/hive-metastore/lib/
+
+ENV PG_CONNECTOR_VERSION=42.3.6
+RUN curl -L https://jdbc.postgresql.org/download/postgresql-$PG_CONNECTOR_VERSION.jar --output /opt/postgresql-$PG_CONNECTOR_VERSION.jar \
+    && ln -s /opt/postgresql-$PG_CONNECTOR_VERSION.jar /opt/hadoop/share/hadoop/common/lib/ \
+    && ln -s /opt/postgresql-$PG_CONNECTOR_VERSION.jar /opt/hive-metastore/lib/ 
 
 EXPOSE 5432
 
@@ -71,6 +76,10 @@ RUN apt-get update && \
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
 RUN export JAVA_HOME
 
+ADD conf/metastore-log4j2.properties /opt/hive-metastore/conf
+ADD /rootfs/opt/bitnami/scripts/postgresql/entrypoint.sh /opt/hive-metastore/bin/entrypoint.sh
+RUN chmod 755 /opt/hive-metastore/bin/entrypoint.sh
+
+ENTRYPOINT [ "/opt/hive-metastore/bin/entrypoint.sh" ]
 USER 1001
-ENTRYPOINT [ "/opt/bitnami/scripts/postgresql/entrypoint.sh" ]
 CMD [ "/opt/bitnami/scripts/postgresql/run.sh" ]

--- a/14/debian-10/Dockerfile
+++ b/14/debian-10/Dockerfile
@@ -64,6 +64,13 @@ RUN curl -L https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java
 
 EXPOSE 5432
 
+RUN apt-get update && \
+    apt-get install -y openjdk-11-jdk ca-certificates-java && \
+    apt-get clean && \
+    update-ca-certificates -f
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
+RUN export JAVA_HOME
+
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/postgresql/entrypoint.sh" ]
 CMD [ "/opt/bitnami/scripts/postgresql/run.sh" ]

--- a/14/debian-10/conf/metastore-log4j2.properties
+++ b/14/debian-10/conf/metastore-log4j2.properties
@@ -1,0 +1,33 @@
+name = metastore
+
+appenders = console, file
+
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{MM/dd/yy HH:mm:ss} %p %c: %m%n
+
+appender.file.type = File
+appender.file.name = fileLogger
+appender.file.fileName = /var/log/hive-metastore/metastore.log
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{MM/dd/yy HH:mm:ss} %p %c: %m%n
+
+loggers = meta
+
+logger.meta.name = org.apache.hadoop.hive.metastore
+logger.meta.level = info
+
+logger.hive.name = org.apache.hive
+logger.hive.level = info
+
+logger.datanucleusorg.name = org.datanucleus
+logger.datanucleusorg.level = info
+
+logger.datanucleus.name = DataNucleus
+logger.datanucleus.level = info
+
+rootLogger.level = info
+rootLogger.appenderRefs = console, file
+rootLogger.appenderRef.console.ref = consoleLogger
+rootLogger.appenderRef.file.ref = fileLogger

--- a/14/debian-10/rootfs/opt/bitnami/scripts/postgresql/entrypoint.sh
+++ b/14/debian-10/rootfs/opt/bitnami/scripts/postgresql/entrypoint.sh
@@ -29,7 +29,9 @@ if [[ "$*" = *"/opt/bitnami/scripts/postgresql/run.sh"* ]]; then
     info "** PostgreSQL setup finished! **"
 fi
 
-# /apache-hive-metastore-3.0.0-bin/bin/schematool -initSchema -dbType postgres
-# /apache-hive-metastore-3.0.0-bin/bin/start-metastore
+#This will initialize the DB and start the metastore
+/opt/apache-hive-metastore-3.0.0-bin/bin/schematool -initSchema -dbType postgres
+/opt/apache-hive-metastore-3.0.0-bin/bin/start-metastore
+
 echo ""
 exec "$@"

--- a/14/debian-10/rootfs/opt/bitnami/scripts/postgresql/entrypoint.sh
+++ b/14/debian-10/rootfs/opt/bitnami/scripts/postgresql/entrypoint.sh
@@ -14,6 +14,9 @@ set -o pipefail
 # Load PostgreSQL environment variables
 . /opt/bitnami/scripts/postgresql-env.sh
 
+export HADOOP_HOME=/opt/hadoop-3.2.0
+export HADOOP_CLASSPATH=${HADOOP_HOME}/share/hadoop/tools/lib/aws-java-sdk-bundle-1.11.375.jar:${HADOOP_HOME}/share/hadoop/tools/lib/hadoop-aws-3.2.0.jar
+
 print_welcome_page
 
 # Enable the nss_wrapper settings
@@ -26,5 +29,7 @@ if [[ "$*" = *"/opt/bitnami/scripts/postgresql/run.sh"* ]]; then
     info "** PostgreSQL setup finished! **"
 fi
 
+# /apache-hive-metastore-3.0.0-bin/bin/schematool -initSchema -dbType postgres
+# /apache-hive-metastore-3.0.0-bin/bin/start-metastore
 echo ""
 exec "$@"


### PR DESCRIPTION
This change is to add the hive-metastore-standalone to postgresql.

It includes adding
- the metastore-standalore
- hadoop
- jdk 11
- the connector
- Entrypoint script modified to include the schematool and start-metastore 